### PR TITLE
Use Deb versioning for Apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM base AS build
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
+# renovate: datasource=repology depName=debian_11/curl versioning=deb
 ENV CURL_VERSION=7.74.0-1.3+deb11u10
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Switch to Deb versioning for Apt packages to support alphanumerical values in version strings.

This avoid having for example `7.74.0-1.3+deb11u9` be seen as a higher version than `7.74.0-1.3+deb11u10` like in #14.