### PR TITLE
No longer build latest and unstable tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-dotnet
-      default-latest-tag: true
+      default-latest-tag: false
       additional-latest-tag-name: 7
-      default-unstable-tag: true
+      default-unstable-tag: false
       additional-unstable-tag-name: 7-unstable
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following example shows the container used for a deployment step which shows
   - stage: deploy
     jobs:
       - deployment: runDotNet
-        container: swissgrc/azure-pipelines-dotnet:latest
+        container: swissgrc/azure-pipelines-dotnet:7
         environment: smarthotel-dev
         strategy:
           runOnce:
@@ -35,10 +35,8 @@ The following example shows the container used for a deployment step which shows
 
 | Tag        | Description                                                                                     | Base Image                         | .NET SDK | Size                                                                                                                              |
 |------------|-------------------------------------------------------------------------------------------------|------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------|
-| latest     | Latest stable release (from `main` branch)                                                      | swissgrc/azure-piplines-git:2.42.1 | 7.0.404  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/latest?style=flat-square)     |
-| 7          | Identical to `latest` tag                                                                       |                                    |          | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/7?style=flat-square)          |
-| unstable   | Latest unstable release (from `develop` branch)                                                 | swissgrc/azure-piplines-git:2.43.0 | 7.0.404  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/unstable?style=flat-square)   |
-| 7-unstable | Identical to `unstable` tag                                                                     |                                    |          | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/7-unstable?style=flat-square) |
+| 7          | Latest stable release (from `main` branch)                                                      | swissgrc/azure-piplines-git:2.42.1 | 7.0.404  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/latest?style=flat-square)     |
+| 7-unstable | Latest unstable release (from `develop` branch)                                                 | swissgrc/azure-piplines-git:2.43.0 | 7.0.404  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/unstable?style=flat-square)   |
 | 7.0.302    | [.NET SDK 7.0.302](https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.5/7.0.302.md) | swissgrc/azure-piplines-git:2.39.2 | 7.0.302  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/7.0.302?style=flat-square)    |
 | 7.0.304    | [.NET SDK 7.0.304](https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.7/7.0.7.md)   | swissgrc/azure-piplines-git:2.39.2 | 7.0.304  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/7.0.304?style=flat-square)    |
 | 7.0.305    | [.NET SDK 7.0.305](https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.8/7.0.8.md)   | swissgrc/azure-piplines-git:2.39.2 | 7.0.305  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/7.0.305?style=flat-square)    |


### PR DESCRIPTION
No longer build latest and unstable tag from this repository, since .NET 8 is now the latest version